### PR TITLE
Fix: Recording a system shortcut results in the app being disabled

### DIFF
--- a/Apptivator/ApplicationState.swift
+++ b/Apptivator/ApplicationState.swift
@@ -28,6 +28,12 @@ import LaunchAtLogin
     private var launchAppAtLogin = LaunchAtLogin.isEnabled
     // Don't fire any shortcuts if user is recording a new shortcut.
     private var currentlyRecording = false
+    // This is intentionally public and prefixed with "_" because *it should not be used*, except as
+    // a workaround for a limitation of MASShortcut. See https://github.com/acheronfail/apptivator/pull/32
+    var _currentlyRecording: Bool {
+        get { return currentlyRecording }
+        set { currentlyRecording = newValue }
+    }
 
     // Whether or not the app is globally enabled.
     private var _isEnabled = true

--- a/Apptivator/UI/PopoverViewController.swift
+++ b/Apptivator/UI/PopoverViewController.swift
@@ -97,6 +97,9 @@ class PopoverViewController: NSViewController {
     override func viewWillDisappear() {
         sequenceEditor?.slideOutAndRemove()
         state.saveToDisk()
+        // Override currentlyRecording state when popover disappears. This is to handle when there
+        // are errors recording shortcuts. See https://github.com/acheronfail/apptivator/pull/32
+        state._currentlyRecording = false
     }
 
     var isSequenceEditorActive: Bool {


### PR DESCRIPTION
When the user tries to register a shortcut already in use by the system (eg, ⌘ + Space) then MASShortcut will popup a dialog explaining that the shortcut is already in use, etc...

This is a problem because we use KVO to disable the application when the shortcut's `isRecording` property changes (so the user doesn't accidentally fire a shortcut while trying to record another one). When this error happens, `isRecording` is never set back to `false`, so our application state remains disabled.

In order to get around this, we have to have a way to manually disable `state.currentlyRecording` which is usually a private field. So we're implementing this workaround as an exception.